### PR TITLE
fix: Update broken links on the tutorial page of the docs

### DIFF
--- a/docs/src/content/docs/tutorial.mdx
+++ b/docs/src/content/docs/tutorial.mdx
@@ -129,8 +129,8 @@ ChunkHound is production-ready and actively tested. For detailed configuration o
 Now that you understand ChunkHound's core concepts:
 
 1. **Start using it** - Index your codebase and connect your AI assistant
-2. **[Advanced configuration](/configuration/)** - Advanced configuration options
-3. **[Technical deep dive](/under-the-hood/)** - Understand the architecture
+2. **[Advanced configuration](/chunkhound/configuration/)** - Advanced configuration options
+3. **[Technical deep dive](/chunkhound/under-the-hood/)** - Understand the architecture
 
 <Aside type="note" title="Questions or Issues?">
 ChunkHound is actively developed. Report issues or ask questions on [GitHub](https://github.com/ofriw/chunkhound/issues).


### PR DESCRIPTION
Fixes a couple of broken links