### PR TITLE
Remove duplicated logic for validating provider args

### DIFF
--- a/chunkhound/api/cli/commands/run.py
+++ b/chunkhound/api/cli/commands/run.py
@@ -158,15 +158,6 @@ def _validate_run_arguments(
             api_key = getattr(args, 'api_key', None)
             base_url = getattr(args, 'base_url', None)
             model = getattr(args, 'model', None)
-            
-            # If no provider info found, provide helpful error
-            if not provider:
-                formatter.error("No embedding provider configured.")
-                formatter.info("To fix this, you can:")
-                formatter.info("  1. Create a .chunkhound.json config file with embedding settings")
-                formatter.info("  2. Use --no-embeddings to skip embeddings")
-                return False
-
         if not validate_provider_args(provider, api_key, base_url, model):
             return False
 

--- a/chunkhound/api/cli/utils/validation.py
+++ b/chunkhound/api/cli/utils/validation.py
@@ -50,9 +50,16 @@ def validate_provider_args(
     """Validate embedding provider arguments."""
     if not provider:
         logger.error(
-            "Embedding provider must be specified. Choose from: openai, voyageai. "
-            "Set via --provider, "
-            "CHUNKHOUND_EMBEDDING__PROVIDER, or in config file."
+            """
+            No embedding provider configured. Choose from: openai, voyageai.
+            To fix this, you can:
+            1) Set via --provider flag
+            2) Set CHUNKHOUND_EMBEDDING__PROVIDER environment variable
+            3) Add provider to .chunkhound.json config file
+            4) Use --no-embeddings to skip embeddings entirely.
+            
+            For more information, see: https://ofriw.github.io/chunkhound/configuration/
+            """
         )
         return False
 

--- a/tests/test_config_missing_behavior.py
+++ b/tests/test_config_missing_behavior.py
@@ -33,8 +33,8 @@ class TestConfigMissingBehavior:
             
             # Should show helpful error message
             assert "No embedding provider configured" in result.stderr, f"Error message not found in stderr: {result.stderr}"
-            assert "Create a .chunkhound.json config file" in result.stdout, f"Config file suggestion not found in stdout: {result.stdout}"
-            assert "--no-embeddings" in result.stdout, f"--no-embeddings option not found in stdout: {result.stdout}"
+            assert ".chunkhound.json config file" in result.stderr, f"Config file suggestion not found in stderr: {result.stderr}"
+            assert "--no-embeddings" in result.stderr, f"--no-embeddings option not found in stderr: {result.stderr}"
 
     def test_no_attribute_error_crash(self):
         """Test that we don't get AttributeError when no config exists (the main bug fix)."""


### PR DESCRIPTION
This change addresses #16, and removes duplicated logic for validating provider configuration. The error message has been updated and now includes a link to the docs.

<img width="760" height="219" alt="image" src="https://github.com/user-attachments/assets/ae034799-8822-437f-a556-37d15c54ceb4" />
