### PR TITLE
Make voyage-code-3 the default VoyageAI embedding model

### DIFF
--- a/chunkhound/core/config/embedding_config.py
+++ b/chunkhound/core/config/embedding_config.py
@@ -176,7 +176,7 @@ class EmbeddingConfig(BaseSettings):
         
         # Provider defaults
         if self.provider == "voyageai":
-            return "voyage-3.5"
+            return "voyage-code-3"
         else:  # openai
             return "text-embedding-3-small"
 

--- a/chunkhound/interfaces/embedding_provider.py
+++ b/chunkhound/interfaces/embedding_provider.py
@@ -212,10 +212,6 @@ class EmbeddingProvider(Protocol):
         """Get list of supported distance metrics."""
         ...
 
-    def get_optimal_batch_size(self) -> int:
-        """Get optimal batch size for this provider."""
-        ...
-
     def get_max_tokens_per_batch(self) -> int:
         """Get maximum tokens per batch for this provider.
         

--- a/chunkhound/providers/embeddings/openai_provider.py
+++ b/chunkhound/providers/embeddings/openai_provider.py
@@ -642,10 +642,6 @@ class OpenAIEmbeddingProvider:
         """Get list of supported distance metrics."""
         return ["cosine", "l2", "ip"]  # OpenAI embeddings work with multiple metrics
 
-    def get_optimal_batch_size(self) -> int:
-        """Get optimal batch size for this provider."""
-        return self._batch_size
-
     def get_max_tokens_per_batch(self) -> int:
         """Get maximum tokens per batch for this provider."""
         if self._model in self._model_config:

--- a/chunkhound/providers/embeddings/voyageai_provider.py
+++ b/chunkhound/providers/embeddings/voyageai_provider.py
@@ -28,12 +28,12 @@ except ImportError:
 
 
 class VoyageAIEmbeddingProvider:
-    """VoyageAI embedding provider using voyage-3.5 by default."""
+    """VoyageAI embedding provider using voyage-code-3 by default."""
 
     def __init__(
         self,
         api_key: str | None = None,
-        model: str = "voyage-3.5",
+        model: str = "voyage-code-3",
         rerank_model: str | None = "rerank-lite-1",
         batch_size: int = 100,
         timeout: int = 30,
@@ -271,17 +271,13 @@ class VoyageAIEmbeddingProvider:
         """Get list of supported distance metrics."""
         return ["cosine"]  # VoyageAI uses cosine similarity
 
-    def get_optimal_batch_size(self) -> int:
-        """Get optimal batch size for this provider."""
-        return min(self._batch_size, 100)  # VoyageAI can handle up to 1000, but 100 is optimal
-
     def get_max_tokens_per_batch(self) -> int:
         """Get maximum tokens per batch for this provider."""
         return self._max_tokens * self._batch_size
 
     def get_max_documents_per_batch(self) -> int:
         """Get maximum documents per batch for VoyageAI provider."""
-        return 1000  # VoyageAI API limit
+        return self.batch_size
 
     # Reranking Operations
     def supports_reranking(self) -> bool:

--- a/chunkhound/registry/__init__.py
+++ b/chunkhound/registry/__init__.py
@@ -88,6 +88,7 @@ class ProviderRegistry:
         """Create an IndexingCoordinator with all dependencies."""
         database_provider = self.get_provider("database")
         embedding_provider = None
+        embedding_service = create_embedding_service()
         
         try:
             embedding_provider = self.get_provider("embedding")
@@ -98,6 +99,7 @@ class ProviderRegistry:
             database_provider=database_provider,
             embedding_provider=embedding_provider,
             language_parsers=self._language_parsers,
+            embedding_service=embedding_service,
         )
 
     def create_search_service(self) -> SearchService:

--- a/tests/provider_configs.py
+++ b/tests/provider_configs.py
@@ -76,7 +76,7 @@ def get_reranking_providers() -> list[tuple[str, type, dict[str, Any]]]:
             VoyageAIEmbeddingProvider,
             {
                 "api_key": api_key,
-                "model": "voyage-3.5",
+                "model": "voyage-code-3",
                 "batch_size": 100,
                 "timeout": 30,
                 "retry_attempts": 3,

--- a/tests/test_database_consistency.py
+++ b/tests/test_database_consistency.py
@@ -25,7 +25,7 @@ async def consistency_services(tmp_path):
     # Standard embedding config
     embedding_config = None
     if api_key and provider:
-        model = "text-embedding-3-small" if provider == "openai" else "voyage-3.5"
+        model = "text-embedding-3-small" if provider == "openai" else "voyage-code-3"
         embedding_config = {
             "provider": provider,
             "api_key": api_key,

--- a/tests/test_embedding_pipeline_integration.py
+++ b/tests/test_embedding_pipeline_integration.py
@@ -25,7 +25,7 @@ async def pipeline_services(tmp_path):
         pytest.skip("No embedding API key available for pipeline integration test")
     
     # Standard embedding config
-    model = "text-embedding-3-small" if provider == "openai" else "voyage-3.5"
+    model = "text-embedding-3-small" if provider == "openai" else "voyage-code-3"
     embedding_config = {
         "provider": provider,
         "api_key": api_key,

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -98,8 +98,8 @@ async def test_real_embedding_api():
         expected_dims = 1536
     elif provider_name == "voyageai":
         from chunkhound.providers.embeddings.voyageai_provider import VoyageAIEmbeddingProvider
-        provider = VoyageAIEmbeddingProvider(api_key=api_key, model="voyage-3.5")
-        expected_dims = 1024  # voyage-3.5 dimensions
+        provider = VoyageAIEmbeddingProvider(api_key=api_key, model="voyage-code-3")
+        expected_dims = 1024  # voyage-code-3 dimensions
     else:
         pytest.skip(f"Unknown provider: {provider_name}")
     
@@ -426,7 +426,7 @@ async def test_real_api():
             provider = OpenAIEmbeddingProvider(api_key=api_key)
         elif provider_name == "voyageai":
             from chunkhound.providers.embeddings.voyageai_provider import VoyageAIEmbeddingProvider
-            provider = VoyageAIEmbeddingProvider(api_key=api_key, model="voyage-3.5")
+            provider = VoyageAIEmbeddingProvider(api_key=api_key, model="voyage-code-3")
         else:
             print(f"❌ Unknown provider: {provider_name}")
             return False

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -39,7 +39,7 @@ class TestMCPIntegration:
         # Configure embedding based on available API key
         embedding_config = None
         if api_key and provider:
-            model = "text-embedding-3-small" if provider == "openai" else "voyage-3.5"
+            model = "text-embedding-3-small" if provider == "openai" else "voyage-code-3"
             embedding_config = {
                 "provider": provider,
                 "api_key": api_key,
@@ -65,7 +65,7 @@ class TestMCPIntegration:
                 embedding_provider = OpenAIEmbeddingProvider(api_key=api_key, model="text-embedding-3-small")
             elif provider == "voyageai":
                 from chunkhound.providers.embeddings.voyageai_provider import VoyageAIEmbeddingProvider
-                embedding_provider = VoyageAIEmbeddingProvider(api_key=api_key, model="voyage-3.5")
+                embedding_provider = VoyageAIEmbeddingProvider(api_key=api_key, model="voyage-code-3")
             else:
                 embedding_provider = None
             

--- a/tests/test_mcp_server_directory_isolation.py
+++ b/tests/test_mcp_server_directory_isolation.py
@@ -587,7 +587,7 @@ def quicksort(arr):
             
             # Get API key and provider configuration
             api_key, provider_name = get_api_key_for_tests()
-            model = "text-embedding-3-small" if provider_name == "openai" else "voyage-3.5"
+            model = "text-embedding-3-small" if provider_name == "openai" else "voyage-code-3"
             
             # Configure embedding based on available API key
             embedding_config = {

--- a/tests/test_qa_deterministic.py
+++ b/tests/test_qa_deterministic.py
@@ -45,7 +45,7 @@ class TestQADeterministic:
         # Create embedding config if available
         embedding_config = None
         if api_key and provider:
-            model = "text-embedding-3-small" if provider == "openai" else "voyage-3.5"
+            model = "text-embedding-3-small" if provider == "openai" else "voyage-code-3"
             embedding_config = {
                 "provider": provider,
                 "api_key": api_key,


### PR DESCRIPTION
I was seeing poor results when generating embeddings with the default `voyage-3.5`, so I've updated the default to the `voyage-code-3` model.

To get voyage-code-3 working properly, I also needed to fix the `batch_size` embedding configuration. This value wasn't being passed to the EmbeddingService due to a hardcoded value in `voyageai_embedding_provider.py`. I've updated this to pull the batch size from config instead.

I also removed `EmbeddingProvider.get_optimal_batch_size` since it appeared to be unused.
The final change was injecting the `EmbeddingService` into the `IndexingCoordinator` to ensure the embedding service is constructed with the proper `batch_size` from the config file.